### PR TITLE
feat: add Lychee link checker to docs-as-code image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Verify Tool Versions
         run: |
           docker run --rm ${{ steps.image-tag.outputs.tag }} \
-          bash -c "vale --version && markdownlint-cli2 --version && htmltest --version && hugo version"
+          bash -c "vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version"
 
       # Verify interactive bash (README usage)
       - name: Verify Interactive Bash

--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,8 @@
 FROM jdkato/vale:latest AS vale
 FROM wjdp/htmltest:latest AS htmltest
 FROM hugomods/hugo:exts AS hugo
+# Lychee link checker (Alpine variant for musl compatibility)
+FROM lycheeverse/lychee:latest-alpine AS lychee
 
 # Final Stage
 FROM node:20-alpine
@@ -13,6 +15,7 @@ RUN apk add --no-cache bash git
 COPY --from=vale /bin/vale /usr/local/bin/
 COPY --from=htmltest /bin/htmltest /usr/local/bin/
 COPY --from=hugo /usr/bin/hugo /usr/local/bin/
+COPY --from=lychee /usr/local/bin/lychee /usr/local/bin/
 
 # Install Node Tools
 COPY package.json /tmp/package.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # docs-as-code
-Builder container image for docs as code
+
+[![Build, publish and sign](https://github.com/doughgle/docs-as-code/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/doughgle/docs-as-code/actions/workflows/docker-publish.yml)
+
+Builder container image for docs-as-code tooling. Used as the single source of
+truth for documentation tool versions across projects.
+
+## Included Tools
+
+| Tool | Purpose | Source |
+|---|---|---|
+| [Vale](https://vale.sh) | Prose linter | `jdkato/vale` |
+| [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | Markdown linter | `npm` (`^0.22.0`) |
+| [htmltest](https://github.com/wjdp/htmltest) | HTML proofer | `wjdp/htmltest` |
+| [Hugo](https://gohugo.io) | Static site generator | `hugomods/hugo` |
+| [Lychee](https://lychee.cli.rs) | Link checker | `lycheeverse/lychee` |
+
+## Usage
+
+```bash
+# Pull the image
+docker pull ghcr.io/doughgle/docs-as-code:main
+
+# Verify tool versions
+docker run --rm ghcr.io/doughgle/docs-as-code:main \
+  sh -c 'vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version'
+
+# Run checks on your documentation
+docker run --rm -v $(pwd):/workspace -w /workspace \
+  ghcr.io/doughgle/docs-as-code:main \
+  sh -c 'markdownlint-cli2 . && vale . && lychee .'
+```
+
+## CI
+
+The image is built on pushes to `main` (when `Containerfile`, `package.json`, or
+`docker-publish.yml` change), on version tags (`v*.*.*`), and on pull requests.
+Builds are signed with [cosign](https://github.com/sigstore/cosign) and pushed
+to `ghcr.io/doughgle/docs-as-code`.
+
+[Workflow](.github/workflows/docker-publish.yml)
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,26 +9,71 @@ truth for documentation tool versions across projects.
 
 | Tool | Purpose | Source |
 |---|---|---|
-| [Vale](https://vale.sh) | Prose linter | `jdkato/vale` |
-| [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | Markdown linter | `npm` (`^0.22.0`) |
-| [htmltest](https://github.com/wjdp/htmltest) | HTML proofer | `wjdp/htmltest` |
+| [Vale](https://vale.sh) | Prose linter — checks style, consistency, and tone | `jdkato/vale` |
+| [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | Markdown linter — catches formatting issues | `npm` (`^0.22.0`) |
+| [htmltest](https://github.com/wjdp/htmltest) | HTML proofer — validates generated site output | `wjdp/htmltest` |
 | [Hugo](https://gohugo.io) | Static site generator | `hugomods/hugo` |
-| [Lychee](https://lychee.cli.rs) | Link checker | `lycheeverse/lychee` |
+| [Lychee](https://lychee.cli.rs) | Link checker — finds broken links in files and pages | `lycheeverse/lychee` |
 
 ## Usage
 
+### Prerequisites
+
+- [Docker](https://docs.docker.com/engine/install/)
+
+### Interactive (local development)
+
+Run individual checks on your documentation by mounting a volume:
+
 ```bash
-# Pull the image
-docker pull ghcr.io/doughgle/docs-as-code:main
+# Lint Markdown files
+docker run --rm -v $(pwd):/src ghcr.io/doughgle/docs-as-code:main \
+  markdownlint-cli2 .
 
-# Verify tool versions
-docker run --rm ghcr.io/doughgle/docs-as-code:main \
-  sh -c 'vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version'
+# Check prose style
+docker run --rm -v $(pwd):/src ghcr.io/doughgle/docs-as-code:main \
+  vale .
 
-# Run checks on your documentation
+# Check links
+docker run --rm -v $(pwd):/src ghcr.io/doughgle/docs-as-code:main \
+  lychee .
+
+# Combine all checks in a single pass
 docker run --rm -v $(pwd):/workspace -w /workspace \
   ghcr.io/doughgle/docs-as-code:main \
   sh -c 'markdownlint-cli2 . && vale . && lychee .'
+```
+
+### CI (GitHub Actions)
+
+Use the image as the runner container for a GitHub Actions job:
+
+```yaml
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    container: ghcr.io/doughgle/docs-as-code:main
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint and check
+        run: |
+          vale .
+          markdownlint-cli2 .
+          lychee .
+
+      - name: Build site
+        run: hugo --minify
+
+      - name: Test HTML
+        run: htmltest
+```
+
+### Verify tool versions
+
+```bash
+docker run --rm ghcr.io/doughgle/docs-as-code:main \
+  sh -c 'vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version'
 ```
 
 ## CI

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![Build, publish and sign](https://github.com/doughgle/docs-as-code/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/doughgle/docs-as-code/actions/workflows/docker-publish.yml)
 
-Builder container image for docs-as-code tooling. Used as the single source of
-truth for documentation tool versions across projects.
+A pre-configured Docker image that bundles Hugo, Vale, markdownlint-cli2, htmltest, and Lychee for docs-as-code workflows. Zero setup, consistent environments across team and CI, and one image to maintain instead of many tools per machine — so you catch style issues, broken links, and formatting errors before they reach production. Pull the image, mount your content, and run the checks, or use it directly as a CI runner container to automate quality gates in every pull request.
+
+## Why Docs-as-Code?
+
+Docs-as-code applies software engineering practices — version control, code review, CI/CD, and automated testing — to documentation. Automated builds and parallel work through branches save time. Reduced rework and self-service publishing lower cost. Style enforcement, link validation, and peer review through pull requests raise quality. This image is the engine that makes the pipeline practical: pull it and you have every tool you need, pre-configured and consistent, from local development to production deployment.
 
 ## Included Tools
 

--- a/specs/docs/implementation-plan.md
+++ b/specs/docs/implementation-plan.md
@@ -1,0 +1,178 @@
+# Add Lychee to docs-as-code Image — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Lychee link checker to the docs-as-code builder container image, update CI verification, and rewrite the README to OSS standards.
+
+**Architecture:** Multi-stage Containerfile addition using the official Lychee Alpine image as a source stage (`COPY --from`), keeping the existing `node:20-alpine` final base untouched. CI verify step extended with a simple `&&` chain. README rewritten to document all tools, usage patterns, and CI status.
+
+**Tech Stack:** Docker multi-stage build, `lycheeverse/lychee:latest-alpine`, GitHub Actions (`.github/workflows/docker-publish.yml`), cosign signing.
+
+## Global Constraints
+
+- Final base image remains `node:20-alpine` — no base image changes
+- Existing tools (Vale, htmltest, Hugo, markdownlint-cli2) must continue working
+- The image build+sign+push workflow must remain functional
+- No new entrypoint, CMD, or runtime changes to the image
+- Lychee version is semi-pinned to `latest-alpine` (verify latest version before implementation, replace `latest-alpine` with a specific version tag if pinning is desired)
+- All `{owner}` and `{repo}` placeholders in README must be replaced with actual GitHub org/user and repo name
+
+---
+
+### Task 1: Add Lychee to Containerfile
+
+**Files:**
+- Modify: `Containerfile`
+
+**Interfaces:**
+- Consumes: Existing multi-stage structure (`FROM jdkato/vale`, `FROM wjdp/htmltest`, `FROM hugomods/hugo`, `FROM node:20-alpine`)
+- Produces: Image with `/usr/local/bin/lychee` available
+
+- [x] **Step 1: Add source stage after the existing Hugo source stage**
+
+Add after line 4 (`FROM hugomods/hugo:exts AS hugo`):
+
+```dockerfile
+# Lychee link checker (Alpine variant for musl compatibility)
+FROM lycheeverse/lychee:latest-alpine AS lychee
+```
+
+- [x] **Step 2: Add COPY command in the final stage after the Hugo COPY**
+
+Add after line 15 (`COPY --from=hugo /usr/bin/hugo /usr/local/bin/`):
+
+```dockerfile
+COPY --from=lychee /usr/local/bin/lychee /usr/local/bin/
+```
+
+Full resulting `Containerfile`:
+
+```dockerfile
+# Source Stages (Dependabot tracks these)
+FROM jdkato/vale:latest AS vale
+FROM wjdp/htmltest:latest AS htmltest
+FROM hugomods/hugo:exts AS hugo
+# Lychee link checker (Alpine variant for musl compatibility)
+FROM lycheeverse/lychee:latest-alpine AS lychee
+
+# Final Stage
+FROM node:20-alpine
+
+# Install System Dependencies
+RUN apk add --no-cache bash git
+
+# Copy Binaries from source stages
+COPY --from=vale /bin/vale /usr/local/bin/
+COPY --from=htmltest /bin/htmltest /usr/local/bin/
+COPY --from=hugo /usr/bin/hugo /usr/local/bin/
+COPY --from=lychee /usr/local/bin/lychee /usr/local/bin/
+
+# Install Node Tools
+COPY package.json /tmp/package.json
+RUN npm install -g markdownlint-cli2
+
+# Set working directory
+WORKDIR /src
+```
+
+- [x] **Step 3: Commit**
+
+```bash
+git add Containerfile
+git commit -m "feat: add lychee link checker to image"
+```
+
+---
+
+### Task 2: Update CI verification step
+
+**Files:**
+- Modify: `.github/workflows/docker-publish.yml` (lines 104-107)
+
+- [x] **Step 1: Add `lychee --version` to the verify command**
+
+Change line 107 from:
+
+```yaml
+          bash -c "vale --version && markdownlint-cli2 --version && htmltest --version && hugo version"
+```
+
+to:
+
+```yaml
+          bash -c "vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version"
+```
+
+Full resulting step in context:
+
+```yaml
+      # Verify tool versions (compatibility with build.yml)
+      - name: Verify Tool Versions
+        run: |
+          docker run --rm ${{ steps.image-tag.outputs.tag }} \
+          bash -c "vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version"
+```
+
+The `&&` chain ensures:
+- All five tools must report their version successfully
+- Any non-zero exit (missing binary, runtime error) fails the step
+- CI logs show the output of each tool up to the failure point
+
+- [x] **Step 2: Commit**
+
+```bash
+git add .github/workflows/docker-publish.yml
+git commit -m "ci: verify lychee version in image build workflow"
+```
+
+---
+
+### Task 3: Rewrite README.md to OSS standards
+
+**Files:**
+- Modify: `README.md`
+
+Replace the single-line description with a comprehensive OSS README: badges, tool inventory table, usage examples, CI explanation, and license.
+
+- [x] **Step 1: Rewrite README** (subsequently expanded with interactive and CI usage examples per review feedback)
+
+```markdown
+# docs-as-code
+...
+```
+
+- [x] **Step 2: Commit** (includes follow-up commit for expanded examples)
+
+```bash
+git add README.md
+git commit -m "docs: rewrite README with tool inventory, usage, and CI documentation"
+```
+
+---
+
+### Verification
+
+After all tasks, run these commands from the repo root:
+
+```bash
+# Build the image locally
+docker build -t docs-as-code:test -f Containerfile .
+
+# Verify all five tools report versions
+docker run --rm docs-as-code:test \
+  sh -c "vale --version && markdownlint-cli2 --version && htmltest --version && hugo version && lychee --version"
+# Expected: all five tools print version info, exit 0
+
+# Verify lychee specifically
+docker run --rm docs-as-code:test lychee --version
+# Expected: lychee <version number>
+```
+
+### Definition of Done
+
+- [ ] `Containerfile` builds successfully with Lychee included ⚠️ needs Docker (unavailable in this env)
+- [ ] `docker run --rm <image> lychee --version` succeeds ⚠️ needs Docker
+- [ ] All five tools (vale, markdownlint-cli2, htmltest, hugo, lychee) report versions from the image ⚠️ needs Docker
+- [x] CI `docker-publish.yml` "Verify Tool Versions" step includes `lychee --version` ✅ verified by file inspection
+- [x] README.md lists all tools, usage patterns, and CI badge ✅ verified by file inspection
+- [ ] Image is pushed to `ghcr.io` with cosign signature ⚠️ needs Docker + deploy


### PR DESCRIPTION
## Summary

Adds the Lychee link checker to the docs-as-code builder container image, updates CI verification, and rewrites the README with comprehensive documentation.

## Changes

1. **Containerfile** — Added `lycheeverse/lychee:latest-alpine` as a multi-stage source, copied binary into final image
2. **CI** — Extended Verify Tool Versions step with `&& lychee --version`
3. **README** — Full rewrite: tool inventory table, interactive usage examples, CI usage section, badges, license

## Verification

- [x] `Containerfile` structure verified by file inspection
- [x] CI workflow YAML verified by file inspection
- [x] README content verified by file inspection
- [ ] Docker build + tool version verification — blocked (no Docker in this environment)

## Related

Closes task items in specs/docs/implementation-plan.md